### PR TITLE
Allow multiple console commands in one alias

### DIFF
--- a/src/main/kotlin/de/elliepotato/commandalias/CommandAlias.kt
+++ b/src/main/kotlin/de/elliepotato/commandalias/CommandAlias.kt
@@ -130,9 +130,9 @@ class CommandAlias : JavaPlugin(), CommandAliasAPI {
                             CommandType.CMD -> server.dispatchCommand(player, processString(formatMessage, player))
                         }
 
-                        if (toEx.consoleCommand != null) {
+                        toEx.consoleCommands.forEach { command ->
                             server.dispatchCommand(server.consoleSender,
-                                    processString(MessageFormat.format(toEx.consoleCommand, *args.toTypedArray()), player)
+                                    processString(MessageFormat.format(command, *args.toTypedArray()), player)
                                             .replace("%alias%", argOne))
                         }
                     } else if (noPermission.isNotEmpty()) {

--- a/src/main/kotlin/de/elliepotato/commandalias/backend/AliasCommand.kt
+++ b/src/main/kotlin/de/elliepotato/commandalias/backend/AliasCommand.kt
@@ -23,7 +23,12 @@ import kotlin.math.max
  */
 class AliasCommand(val label: String, var enabled: Boolean, val permission: String?, val aliases: List<String>,
                    val type: CommandType = CommandType.CMD, val runConditions: Map<String, Any> = Maps.newHashMap(),
-                   val consoleCommand: String?) {
+                   val consoleCommands: List<String>) {
+
+    @Deprecated("In versions until 1.6.1 only one console command could be specified." +
+            "This getter is for api backwards-compatibility",
+            replaceWith = ReplaceWith("consoleCommands"))
+    val consoleCommand: String? = consoleCommands.firstOrNull()
 
     private val placeholderIndexes: MutableList<Pair<Int, Int>>
 

--- a/src/main/kotlin/de/elliepotato/commandalias/backend/AliasConfig.kt
+++ b/src/main/kotlin/de/elliepotato/commandalias/backend/AliasConfig.kt
@@ -107,11 +107,10 @@ class AliasConfig(private val plugin: CommandAlias) {
                         .map { m -> color(m) }
                         .collect(Collectors.toList())
                 // console command
-                val consoleCommand =
-                        if (cfg.isList("commands.$path.console-command"))
-                            cfg.getStringList("commands.$path.console-command")
-                        else
-                            listOf(cfg.getString("commands.$path.console-command"))
+                val consoleCommands =
+                        if (cfg.isString("commands.$path.console-command"))
+                            listOf(cfg.getString("commands.$path.console-command")!!)
+                        else cfg.getStringList("commands.$path.console-command")
                 // type
                 val type: CommandType = CommandType.values().firstOrNull { path.startsWith(it.prefix) }
                         ?: CommandType.CMD
@@ -126,7 +125,7 @@ class AliasConfig(private val plugin: CommandAlias) {
                 }
 
                 try {
-                    val command = AliasCommand(label, enabled, permission, aliases, type, runConditions, consoleCommand)
+                    val command = AliasCommand(label, enabled, permission, aliases, type, runConditions, consoleCommands)
                     commands[label.toLowerCase()] = command
                 } catch (e: IllegalStateException) {
                     plugin.log("The config is improperly defined! Cannot load alias $path.", Level.SEVERE)

--- a/src/main/kotlin/de/elliepotato/commandalias/backend/AliasConfig.kt
+++ b/src/main/kotlin/de/elliepotato/commandalias/backend/AliasConfig.kt
@@ -107,7 +107,11 @@ class AliasConfig(private val plugin: CommandAlias) {
                         .map { m -> color(m) }
                         .collect(Collectors.toList())
                 // console command
-                val consoleCommand = cfg.getString("commands.$path.console-command")
+                val consoleCommand =
+                        if (cfg.isList("commands.$path.console-command"))
+                            cfg.getStringList("commands.$path.console-command")
+                        else
+                            listOf(cfg.getString("commands.$path.console-command"))
                 // type
                 val type: CommandType = CommandType.values().firstOrNull { path.startsWith(it.prefix) }
                         ?: CommandType.CMD


### PR DESCRIPTION
Having to register many different commands for the same alias is reasonable because it greatly improves readability when just one command is to be executed for the alias. But for the console command the syntax for one ore many commands is barely different, so it makes sense to allow many console commands for one alias.
This PR does not break old configs nor the API